### PR TITLE
Session store

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ Some that you probably want to change:
 
 Cognicity-rem-server requires a database that conforms to the [Cognicity framework schema](https://github.com/smart-facility/cognicity-schema).
 
+You need to setup the session storage schema - run a command like
+```shell
+psql mydatabase < node_modules/connect-pg-simple/table.sql
+```
+See https://github.com/voxpelli/node-connect-pg-simple for more details.
+
 You will also need to import the SQL files from the schema directory.
 
 #### Authentication

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "body-parser": "^1.14.1",
     "connect-ensure-login": "^0.1.1",
+    "connect-pg-simple": "^3.1.0",
     "cookie-parser": "^1.4.0",
     "express": "^4.13.3",
     "express-session": "^1.12.1",

--- a/server.js
+++ b/server.js
@@ -245,17 +245,18 @@ app.use( morgan('combined', { stream : winstonStream } ) );
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(cookieParser());
 
-//app.use(expressSession({ secret: config.auth.sessionSecret, resave: false, saveUninitialized: false }));
 app.use(expressSession({
 	store: new pgSession({
-		pg : pg,                                  // Use global pg-module
-		conString : config.pg.conString, // Connect using something else than default DATABASE_URL env variable
-		errorLog: logger.error
+		pg : pg, // Use this instance of pg
+		conString : config.pg.conString, // Connect to PG with this string
+		errorLog: logger.error // If error can't be returned in a callback, log it with this method
 	}),
-	secret: config.auth.sessionSecret,
-	resave: false,
-	cookie: { maxAge: 30 * 24 * 60 * 60 * 1000 }, // 30 days	
-	saveUninitialized: false
+	secret: config.auth.sessionSecret, // Sign session ID cookie with this
+	resave: false, // pg session store allows us to set this to false as recommended by express-session
+	cookie: { 
+		maxAge: 30 * 24 * 60 * 60 * 1000 // 30 days
+	}, 
+	saveUninitialized: false // Don't save session until we have data to save
 }));
 
 app.use(passport.initialize());


### PR DESCRIPTION
Replace built-on non-production-ready session store with postgres one.

**_NOTE: This requires a schema update to the REM DB server before deploying this version of the code._**

E.g.:

``` shell
psql mydatabase < node_modules/connect-pg-simple/table.sql
```

Will create a table called 'session' on the database in the default schema.

See https://github.com/voxpelli/node-connect-pg-simple for more details.
